### PR TITLE
Make the build work on windows msvc targets

### DIFF
--- a/crates/opencascade-sys/build.rs
+++ b/crates/opencascade-sys/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    let target = std::env::var("TARGET").expect("No TARGET environment variable defined");
+    let is_windows = target.to_lowercase().contains("windows");
+
     let dst = cmake::Config::new("OCCT")
         .define("BUILD_LIBRARY_TYPE", "Static")
         .define("BUILD_MODULE_Draw", "FALSE")
@@ -34,6 +37,10 @@ fn main() {
     println!("cargo:rustc-link-lib=static=TKBool");
     println!("cargo:rustc-link-lib=static=TKBO");
     println!("cargo:rustc-link-lib=static=TKOffset");
+
+    if is_windows {
+        println!("cargo:rustc-link-lib=dylib=user32");
+    }
 
     cxx_build::bridge("src/lib.rs")
         .cpp(true)


### PR DESCRIPTION
Hey @DSchroer, it seems the undefined symbols were due to us missing a link to `user32.lib`. I tested this on a windows machine with the default stable toolchain for windows (`x86_64-pc-windows-msvc`).

I'd appreciate a test in your mingw setup if you have time.